### PR TITLE
Add operator[]

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Synopsis
 | &nbsp;         |&#10003;| **front**() noexcept   | const_reference to element at front |
 | &nbsp;         |&#10003;| **back**() noexcept    | reference to back element at back |
 | &nbsp;         |&#10003;| **back**() noexcept    | const_reference to element at back |
+| &nbsp;         |&ndash; | **operator[]**( size_type idx ) noexcept | reference to element at specified index |
+| &nbsp;         |&ndash; | **operator[]**( size_type idx ) noexcept | const_reference to element at specified index |
 | Elem.extraction|&#10003;| **pop_front**() | Popper::return_type (p0059: auto) |
 | &nbsp;         |&ndash; | **pop_back**()  | Popper::return_type |
 | Elem.insertion|&#10003; | **push_back**( value_type const & value ) noexcept(&hellip;) | void; restrained (>= C++11) |

--- a/include/nonstd/ring_span.hpp
+++ b/include/nonstd/ring_span.hpp
@@ -480,6 +480,18 @@ public:
 
     // element access:
 
+#if nsrs_RING_SPAN_LITE_EXTENSION
+    reference operator[]( size_type idx ) nsrs_noexcept
+    {
+        return assert( idx < m_size ), at_(idx);
+    }
+
+    const_reference operator[]( size_type idx ) const nsrs_noexcept
+    {
+        return assert( idx < m_size ), at_(idx);
+    }
+#endif
+
     reference front() nsrs_noexcept
     {
         return *begin();
@@ -702,12 +714,12 @@ private:
         return idx % m_capacity;
     }
 
-    reference at( size_type idx ) nsrs_noexcept
+    reference at_( size_type idx ) nsrs_noexcept
     {
         return m_data[ normalize_(m_front_idx + idx) ];
     }
 
-    const_reference at( size_type idx ) const nsrs_noexcept
+    const_reference at_( size_type idx ) const nsrs_noexcept
     {
         return m_data[ normalize_(m_front_idx + idx) ];
     }
@@ -826,7 +838,7 @@ public:
 
     reference operator*() const nsrs_noexcept
     {
-        return m_rs->at( m_idx );
+        return m_rs->at_( m_idx );
     }
 
     // advance iterator:

--- a/test/ring-span.t.cpp
+++ b/test/ring-span.t.cpp
@@ -169,6 +169,19 @@ CASE( "ring_span: Allows to check for a full span" )
     EXPECT( rs.full() );
 }
 
+CASE( "ring_span: Allows to observe the element at the specified index" )
+{
+#if nsrs_CONFIG_STRICT_P0059
+    EXPECT( !!"operator[] is not available (SG14)" );
+#else
+    int arr[] = { 1, 2, 3, }; ring_span<int> rs( arr, arr + dim(arr), arr, dim(arr) );
+
+    EXPECT( rs[0] == arr[0] );
+    EXPECT( rs[1] == arr[1] );
+    EXPECT( rs[2] == arr[2] );
+#endif
+}
+
 CASE( "ring_span: Allows to observe the element at the front" )
 {
     int arr[] = { 1, 2, 3, }; ring_span<int> rs( arr, arr + dim(arr), arr, dim(arr) );


### PR DESCRIPTION
Thanks for the handy library!

It seems that it would be convenient to add the operator[] to access the elements. For example, [std::span](https://en.cppreference.com/w/cpp/container/span) allows it.