### PR TITLE
Iterator additions to match concept std::random_access_iterator

### DIFF
--- a/include/nonstd/ring_span.hpp
+++ b/include/nonstd/ring_span.hpp
@@ -936,10 +936,12 @@ class ring_iterator : public std::iterator
 template< class RS, bool is_const >
 class ring_iterator
 {
+    friend RS;  // clang: non-class friend type 'RS' is a C++11 extension [-Wc++11-extensions]
 public:
     typedef ring_iterator<RS, is_const> type;
 
     typedef std::ptrdiff_t difference_type;
+    typedef typename RS::size_type size_type;
     typedef typename RS::value_type value_type;
 
     typedef typename std11::conditional<is_const, const value_type, value_type>::type * pointer;
@@ -974,6 +976,20 @@ public:
     {
         return & m_rs->at_( m_idx );
     }
+
+    // see issue #30:
+
+#if nsrs_RING_SPAN_LITE_EXTENSION
+    reference operator[]( size_type idx ) nsrs_noexcept
+    {
+        return m_rs->at_(m_idx + idx);
+    }
+
+    const reference operator[]( size_type idx ) const nsrs_noexcept
+    {
+        return m_rs->at_(m_idx + idx);
+    }
+#endif
 
     // advance iterator:
 
@@ -1066,10 +1082,8 @@ public:
     }
 
 private:
-    friend RS;  // clang: non-class friend type 'RS' is a C++11 extension [-Wc++11-extensions]
     friend class ring_iterator<RS, ! is_const>;
 
-    typedef typename RS::size_type size_type;
     typedef typename std11::conditional<is_const, const RS, RS>::type ring_type;
 
     ring_iterator( size_type idx, typename std11::conditional<is_const, const RS, RS>::type * rs ) nsrs_noexcept

--- a/include/nonstd/ring_span.hpp
+++ b/include/nonstd/ring_span.hpp
@@ -1105,6 +1105,12 @@ inline ring_iterator<RS,C> operator+( ring_iterator<RS,C> it, int i ) nsrs_noexc
 }
 
 template< class RS, bool C >
+inline ring_iterator<RS,C> operator+(  int i, ring_iterator<RS,C> it ) nsrs_noexcept
+{
+    it += i; return it;
+}
+
+template< class RS, bool C >
 inline ring_iterator<RS,C> operator-( ring_iterator<RS,C> it, int i ) nsrs_noexcept
 {
     it -= i; return it;

--- a/test/ring-span.t.cpp
+++ b/test/ring-span.t.cpp
@@ -865,6 +865,20 @@ CASE( "ring_iterator: Allows to dereference iterator (operator->())" )
     EXPECT( rs.begin()->v == arr[0].v );
 }
 
+CASE( "ring_iterator: Allows to index from iterator (operator[](size_t))" )
+{
+    using op_arrow::S;
+
+    S arr[] = { {1}, {2}, {3}, }; ring_span<S> rs( &arr[0], &arr[0] + dim(arr), &arr[0], dim(arr) );
+
+    EXPECT( rs.begin()[0].v == arr[0].v );
+    EXPECT( rs.begin()[1].v == arr[1].v );
+    EXPECT( (rs.begin() + 1)[0].v == arr[1].v );
+    EXPECT( (rs.begin() + 1)[1].v == arr[2].v );
+    // explicit const iterator
+    EXPECT( rs.cbegin()[0].v == arr[0].v );
+}
+
 CASE( "ring_iterator: Allows to increment iterator (prefix)" )
 {
     int arr[] = { 1, 2, 3, }; ring_span<int> rs( &arr[0], &arr[0] + dim(arr), &arr[0], dim(arr) );

--- a/test/ring-span.t.cpp
+++ b/test/ring-span.t.cpp
@@ -944,6 +944,7 @@ CASE( "ring_iterator: Allows to offset iterator (+)" " [extension]" )
     ring_span<int>::iterator pos = rs.begin();
 
     EXPECT( *(pos + 2) == arr[2] );
+    EXPECT( *(2 + pos) == arr[2] );
 #endif
 }
 


### PR DESCRIPTION
Fixes #30 

C++20 concept `std::random_access_iterator` requires that the iterator is indexable and that addition is commutative. These requirements are not currently met in master

[Godbolt](https://godbolt.org/z/337nPc5cf) showing that the example used in the issue compiles when built from the fork